### PR TITLE
feat:Export playlist metadata

### DIFF
--- a/src/plugins/playlist-exporter/backend.ts
+++ b/src/plugins/playlist-exporter/backend.ts
@@ -1,0 +1,33 @@
+import { dialog } from 'electron';
+import { promises as fs } from 'fs';
+import type { BackendContext } from '../../types/contexts';
+
+const convertToCSV = (data: any[]) => {
+  if (data.length === 0) return '';
+  const header = Object.keys(data[0]).join(',');
+  const rows = data.map(row =>
+    Object.values(row).map(value => `"${String(value).replace(/"/g, '""')}"`).join(',')
+  );
+  return [header, ...rows].join('\n');
+};
+
+// Add the config type to BackendContext
+export const backend = ({ ipc }: BackendContext<{ enabled: true }>) => {
+  ipc.on('save-playlist-data', async (_: any, data: any[]) => {
+    const csvData = convertToCSV(data);
+    if (!csvData) {
+      dialog.showErrorBox('Export Failed', 'There are no songs to export.');
+      return;
+    }
+
+    const { filePath } = await dialog.showSaveDialog({
+      title: 'Save Playlist as CSV',
+      defaultPath: 'playlist.csv',
+      filters: [{ name: 'CSV Files', extensions: ['csv'] }],
+    });
+
+    if (filePath) {
+      await fs.writeFile(filePath, csvData);
+    }
+  });
+};

--- a/src/plugins/playlist-exporter/index.ts
+++ b/src/plugins/playlist-exporter/index.ts
@@ -1,0 +1,21 @@
+import { createPlugin } from '../../utils';
+import { backend } from './backend';
+import { renderer } from './renderer';
+
+export default createPlugin({
+  name: () => 'Playlist Exporter',
+  restartNeeded: false,
+  config: {
+    enabled: true,
+  },
+  menu: ({ window }) => [
+    {
+      label: 'Export Current Queue to CSV',
+      click: () => {
+        window.webContents.send('export-playlist');
+      },
+    },
+  ],
+  backend,
+  renderer,
+});

--- a/src/plugins/playlist-exporter/renderer.ts
+++ b/src/plugins/playlist-exporter/renderer.ts
@@ -1,0 +1,32 @@
+import type { RendererContext } from '../../types/contexts';
+
+export const renderer = ({ ipc }: RendererContext<any>) => {
+  let playerApi: any = null;
+
+  (window as any).onPlayerApiReady((api: any) => {
+    playerApi = api;
+  });
+
+  ipc.on('export-playlist', () => {
+    if (!playerApi) {
+      alert('Player API not ready yet. Please wait a moment and try again.');
+      return;
+    }
+
+    const queue = playerApi.getQueue();
+    if (!queue || queue.length === 0) {
+      alert('No songs in the queue to export.');
+      return;
+    }
+
+    const playlistData = queue.map((song: any) => ({
+      title: song.videoDetails?.title,
+      artist: song.videoDetails?.author,
+      album: song.videoDetails?.album,
+      durationSeconds: song.videoDetails?.lengthSeconds,
+      videoId: song.videoDetails?.videoId,
+    }));
+
+    ipc.invoke('save-playlist-data', playlistData);
+  });
+};


### PR DESCRIPTION
Title: feat(plugins): Add Playlist Exporter
Description:
This pull request introduces a new plugin, Playlist Exporter, which allows users to export their current song queue to a CSV file.

Motivation
Currently, there is no easy way to get a structured list of songs from a playlist or queue out of the application. This plugin solves that problem by providing a simple, one-click solution to export the current queue's metadata (including title, artist, album, duration, and video ID) into a universally compatible CSV format.

This addresses the user need to manage, archive, or share playlist data without cumbersome manual effort, as requested in issue #[issue number].

Implementation
Adds a new plugin in src/plugins/playlist-exporter.

The plugin was built following the official guide in the README.md, with separate backend.ts and renderer.ts files for a clean separation of concerns.

An "Export Current Queue to CSV" option is added to the main application menu.

Uses Electron's dialog for a native "Save File" experience.

How to Test
Enable the "Playlist Exporter" plugin in the options.

Play any song to populate the song queue.

From the top menu, select "Export Current Queue to CSV".

A save dialog should appear. Choose a location to save the playlist.csv file.

Open the saved file and verify that the song data is accurate and correctly formatted.

Resolves #3972 